### PR TITLE
Refactoring Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactoring.yml
+++ b/.github/ISSUE_TEMPLATE/refactoring.yml
@@ -109,20 +109,20 @@ body:
       label: 🔧 **Refactoring Type**
       options:
         - Code Duplication Removal
-        - Function Decomposition
-        - Performance Optimization
-        - Error Handling Standardization        - Parameter Validation Improvement
+        - Function Decomposition        - Performance Optimization
+        - Error Handling Standardization
+        - Parameter Validation Improvement
         - Class/Module Restructuring
         - Design Pattern Implementation
         - Other
       description: What type of refactoring is this?
     validations:
       required: true
-
   - type: dropdown
     id: priority
     attributes:
-      label: 🚩 **Priority**      options:
+      label: 🚩 **Priority**
+      options:
         - priority: low
         - priority: medium
         - priority: high
@@ -167,8 +167,8 @@ body:
     id: additional_context
     attributes:
       label: 📚 **Additional Context**
-      description: Any additional information that would be helpful for this refactoring.
-      placeholder: |        - Related refactoring opportunities
+      description: Any additional information that would be helpful for this refactoring.      placeholder: |
+        - Related refactoring opportunities
         - Dependencies that need to be considered
         - Timeline considerations
         - References to coding standards or best practices

--- a/.github/ISSUE_TEMPLATE/refactoring.yml
+++ b/.github/ISSUE_TEMPLATE/refactoring.yml
@@ -106,10 +106,10 @@ body:
   - type: dropdown
     id: refactor_type
     attributes:
-      label: 🔧 **Refactoring Type**
-      options:
+      label: 🔧 **Refactoring Type**      options:
         - Code Duplication Removal
-        - Function Decomposition        - Performance Optimization
+        - Function Decomposition
+        - Performance Optimization
         - Error Handling Standardization
         - Parameter Validation Improvement
         - Class/Module Restructuring
@@ -164,10 +164,10 @@ body:
         - label: I can help with testing and validation
 
   - type: textarea
-    id: additional_context
-    attributes:
+    id: additional_context    attributes:
       label: 📚 **Additional Context**
-      description: Any additional information that would be helpful for this refactoring.      placeholder: |
+      description: Any additional information that would be helpful for this refactoring.
+      placeholder: |
         - Related refactoring opportunities
         - Dependencies that need to be considered
         - Timeline considerations


### PR DESCRIPTION
## Summary of Fixes

The `refactoring.yml` template had YAML syntax errors that prevented GitHub from recognizing it as a valid issue template:
- **Fixed line 110:** Separated "Function Decomposition" and "Performance Optimization" into separate list items.
- **Fixed line 165:** Added proper line break between `description` and `placeholder` fields.

These syntax errors would cause GitHub to ignore the template entirely, which is why it wasn't showing up in your repository's "New Issue" interface. The template should now appear correctly alongside your other issue templates (Documentation Improvement and Feature Request).