### PR TITLE
Fix comment formatting in NetworkOperations

### DIFF
--- a/PSNetworkAdministrator/Private/NetworkOperations.ps1
+++ b/PSNetworkAdministrator/Private/NetworkOperations.ps1
@@ -329,7 +329,9 @@ function Invoke-NetworkOperationWithFallback {
     Array of fallback operations to try
 
     .PARAMETER OperationName
-    Name of the operation for logging    .PARAMETER TimeoutSeconds
+    Name of the operation for logging
+
+    .PARAMETER TimeoutSeconds
     Timeout for each operation attempt
 
     .EXAMPLE


### PR DESCRIPTION
## Summary
- fix comment formatting for `Invoke-NetworkOperationWithFallback`

## Testing
- `pwsh -NoLogo -Command "Import-Module ./PSNetworkAdministrator/PSNetworkAdministrator.psd1 -Force -Verbose" | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_6856d32694548331b125738a26072201