### PR TITLE
Fix port connectivity operation string quoting

### DIFF
--- a/PSNetworkAdministrator/Private/NetworkOperations.ps1
+++ b/PSNetworkAdministrator/Private/NetworkOperations.ps1
@@ -141,7 +141,7 @@ function Test-NetworkAdminPortConnectivity {
         Test-NetConnection -ComputerName $Target -Port $Port -WarningAction SilentlyContinue -ErrorAction Stop
     }
     
-    $result = Invoke-NetworkAdminNetworkOperationWithTimeout -Operation $portTestOperation -TimeoutSeconds $TimeoutSeconds -OperationName "Port Test to $Target`:$Port"
+    $result = Invoke-NetworkAdminNetworkOperationWithTimeout -Operation $portTestOperation -TimeoutSeconds $TimeoutSeconds -OperationName "Port Test to $Target:$Port"
     
     return $result
 }


### PR DESCRIPTION
## Summary
- correct quoting for the Port Test operation in `NetworkOperations.ps1`

## Testing
- `pwsh -NoLogo -Command "Import-Module './PSNetworkAdministrator/PSNetworkAdministrator.psd1' -Force -Verbose"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856d994f7008331baffcb9b2d1f8132